### PR TITLE
UPC++ reductions if complex type

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ TAMM build instructions can be found [here](docs/install.md)
 
 ## Contributors
 
-* [Max Grossman](https://github.com/agrippa), [The UPC++ Team](https://bitbucket.org/berkeleylab/upcxx/wiki/Home) (UPC++ port)
+* [Johnny Corbino](https://crd.lbl.gov/divisions/amcr/computer-science-amcr/class/members/class-staff/johnny-corbino), [The UPC++ Team](https://bitbucket.org/berkeleylab/upcxx/wiki/Home) (UPC++ port)

--- a/src/tamm/proc_group.hpp
+++ b/src/tamm/proc_group.hpp
@@ -436,13 +436,21 @@ public:
     T result{};
 #if defined(USE_UPCXX)
     if(op == ReduceOp::min) {
-      upcxx::reduce_one(buf, &result, 1, [](const T& a, const T& b){ return std::abs(a) < std::abs(b) ? a : b; }, root, *pginfo_->team_).wait();
+      upcxx::reduce_one(
+        buf, &result, 1, [](const T& a, const T& b) { return std::abs(a) < std::abs(b) ? a : b; },
+        root, *pginfo_->team_)
+        .wait();
     }
     else if(op == ReduceOp::max) {
-      upcxx::reduce_one(buf, &result, 1, [](const T& a, const T& b){ return std::abs(a) > std::abs(b) ? a : b; }, root, *pginfo_->team_).wait();
+      upcxx::reduce_one(
+        buf, &result, 1, [](const T& a, const T& b) { return std::abs(a) > std::abs(b) ? a : b; },
+        root, *pginfo_->team_)
+        .wait();
     }
     else if(op == ReduceOp::sum) {
-      upcxx::reduce_one(buf, &result, 1, [](const T& a, const T& b){ return a + b; }, root, *pginfo_->team_).wait();
+      upcxx::reduce_one(
+        buf, &result, 1, [](const T& a, const T& b) { return a + b; }, root, *pginfo_->team_)
+        .wait();
     }
     else { abort(); }
 #else
@@ -473,13 +481,21 @@ public:
   void reduce(const T* sbuf, T* rbuf, int count, ReduceOp op, int root) {
 #if defined(USE_UPCXX)
     if(op == ReduceOp::min) {
-      upcxx::reduce_one(sbuf, rbuf, count, [](const T& a, const T& b){ return std::abs(a) < std::abs(b) ? a : b; }, root, *pginfo_->team_).wait();
+      upcxx::reduce_one(
+        sbuf, rbuf, count, [](const T& a, const T& b) { return std::abs(a) < std::abs(b) ? a : b; },
+        root, *pginfo_->team_)
+        .wait();
     }
     else if(op == ReduceOp::max) {
-      upcxx::reduce_one(sbuf, rbuf, count, [](const T& a, const T& b){ return std::abs(a) > std::abs(b) ? a : b; }, root, *pginfo_->team_).wait();
+      upcxx::reduce_one(
+        sbuf, rbuf, count, [](const T& a, const T& b) { return std::abs(a) > std::abs(b) ? a : b; },
+        root, *pginfo_->team_)
+        .wait();
     }
     else if(op == ReduceOp::sum) {
-      upcxx::reduce_one(sbuf, rbuf, count, [](const T& a, const T& b){ return a + b; }, root, *pginfo_->team_).wait();
+      upcxx::reduce_one(
+        sbuf, rbuf, count, [](const T& a, const T& b) { return a + b; }, root, *pginfo_->team_)
+        .wait();
     }
     else { abort(); }
 #else
@@ -512,13 +528,21 @@ public:
     T result{};
 #if defined(USE_UPCXX)
     if(op == ReduceOp::min) {
-      upcxx::reduce_all(buf, &result, 1, [](const T& a, const T& b){ return std::abs(a) < std::abs(b) ? a : b; }, *pginfo_->team_).wait();
+      upcxx::reduce_all(
+        buf, &result, 1, [](const T& a, const T& b) { return std::abs(a) < std::abs(b) ? a : b; },
+        *pginfo_->team_)
+        .wait();
     }
     else if(op == ReduceOp::max) {
-      upcxx::reduce_all(buf, &result, 1, [](const T& a, const T& b){ return std::abs(a) > std::abs(b) ? a : b; }, *pginfo_->team_).wait();
+      upcxx::reduce_all(
+        buf, &result, 1, [](const T& a, const T& b) { return std::abs(a) > std::abs(b) ? a : b; },
+        *pginfo_->team_)
+        .wait();
     }
     else if(op == ReduceOp::sum) {
-      upcxx::reduce_all(buf, &result, 1, [](const T& a, const T& b){ return a + b; }, *pginfo_->team_).wait();
+      upcxx::reduce_all(
+        buf, &result, 1, [](const T& a, const T& b) { return a + b; }, *pginfo_->team_)
+        .wait();
     }
     else { abort(); }
 #else
@@ -551,13 +575,21 @@ public:
 #if defined(USE_UPCXX)
 
     if(op == ReduceOp::min) {
-      upcxx::reduce_all(sbuf, rbuf, count, [](const T& a, const T& b){ return std::abs(a) < std::abs(b) ? a : b; }, *pginfo_->team_).wait();
+      upcxx::reduce_all(
+        sbuf, rbuf, count, [](const T& a, const T& b) { return std::abs(a) < std::abs(b) ? a : b; },
+        *pginfo_->team_)
+        .wait();
     }
     else if(op == ReduceOp::max) {
-      upcxx::reduce_all(sbuf, rbuf, count, [](const T& a, const T& b){ return std::abs(a) > std::abs(b) ? a : b; }, *pginfo_->team_).wait();
+      upcxx::reduce_all(
+        sbuf, rbuf, count, [](const T& a, const T& b) { return std::abs(a) > std::abs(b) ? a : b; },
+        *pginfo_->team_)
+        .wait();
     }
     else if(op == ReduceOp::sum) {
-      upcxx::reduce_all(sbuf, rbuf, count, [](const T& a, const T& b){ return a + b; }, *pginfo_->team_).wait();
+      upcxx::reduce_all(
+        sbuf, rbuf, count, [](const T& a, const T& b) { return a + b; }, *pginfo_->team_)
+        .wait();
     }
     else { abort(); }
 #else

--- a/src/tamm/proc_group.hpp
+++ b/src/tamm/proc_group.hpp
@@ -411,7 +411,7 @@ public:
   }
 #endif
 
-  template<typename T>
+  template<typename T, typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
   T reduce(const T* buf, ReduceOp op, int root) {
     T result{};
 #if defined(USE_UPCXX)
@@ -432,6 +432,26 @@ public:
   }
 
   template<typename T>
+  T reduce(const T* buf, ReduceOp op, int root) {
+    T result{};
+#if defined(USE_UPCXX)
+    if(op == ReduceOp::min) {
+      upcxx::reduce_one(buf, &result, 1, [](const T& a, const T& b){ return std::abs(a) < std::abs(b) ? a : b; }, root, *pginfo_->team_).wait();
+    }
+    else if(op == ReduceOp::max) {
+      upcxx::reduce_one(buf, &result, 1, [](const T& a, const T& b){ return std::abs(a) > std::abs(b) ? a : b; }, root, *pginfo_->team_).wait();
+    }
+    else if(op == ReduceOp::sum) {
+      upcxx::reduce_one(buf, &result, 1, [](const T& a, const T& b){ return a + b; }, root, *pginfo_->team_).wait();
+    }
+    else { abort(); }
+#else
+    MPI_Reduce(buf, &result, 1, mpi_type<T>(), mpi_op(op), root, pginfo_->mpi_comm_);
+#endif
+    return result;
+  }
+
+  template<typename T, typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
   void reduce(const T* sbuf, T* rbuf, int count, ReduceOp op, int root) {
 #if defined(USE_UPCXX)
     if(op == ReduceOp::min) {
@@ -450,6 +470,24 @@ public:
   }
 
   template<typename T>
+  void reduce(const T* sbuf, T* rbuf, int count, ReduceOp op, int root) {
+#if defined(USE_UPCXX)
+    if(op == ReduceOp::min) {
+      upcxx::reduce_one(sbuf, rbuf, count, [](const T& a, const T& b){ return std::abs(a) < std::abs(b) ? a : b; }, root, *pginfo_->team_).wait();
+    }
+    else if(op == ReduceOp::max) {
+      upcxx::reduce_one(sbuf, rbuf, count, [](const T& a, const T& b){ return std::abs(a) > std::abs(b) ? a : b; }, root, *pginfo_->team_).wait();
+    }
+    else if(op == ReduceOp::sum) {
+      upcxx::reduce_one(sbuf, rbuf, count, [](const T& a, const T& b){ return a + b; }, root, *pginfo_->team_).wait();
+    }
+    else { abort(); }
+#else
+    MPI_Reduce(sbuf, rbuf, count, mpi_type<T>(), mpi_op(op), root, pginfo_->mpi_comm_);
+#endif
+  }
+
+  template<typename T, typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
   T allreduce(const T* buf, ReduceOp op) {
     T result{};
 #if defined(USE_UPCXX)
@@ -470,6 +508,26 @@ public:
   }
 
   template<typename T>
+  T allreduce(const T* buf, ReduceOp op) {
+    T result{};
+#if defined(USE_UPCXX)
+    if(op == ReduceOp::min) {
+      upcxx::reduce_all(buf, &result, 1, [](const T& a, const T& b){ return std::abs(a) < std::abs(b) ? a : b; }, *pginfo_->team_).wait();
+    }
+    else if(op == ReduceOp::max) {
+      upcxx::reduce_all(buf, &result, 1, [](const T& a, const T& b){ return std::abs(a) > std::abs(b) ? a : b; }, *pginfo_->team_).wait();
+    }
+    else if(op == ReduceOp::sum) {
+      upcxx::reduce_all(buf, &result, 1, [](const T& a, const T& b){ return a + b; }, *pginfo_->team_).wait();
+    }
+    else { abort(); }
+#else
+    MPI_Allreduce(buf, &result, 1, mpi_type<T>(), mpi_op(op), pginfo_->mpi_comm_);
+#endif
+    return result;
+  }
+
+  template<typename T, typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
   void allreduce(const T* sbuf, T* rbuf, int count, ReduceOp op) {
 #if defined(USE_UPCXX)
 
@@ -481,6 +539,25 @@ public:
     }
     else if(op == ReduceOp::sum) {
       upcxx::reduce_all(sbuf, rbuf, count, upcxx::op_fast_add, *pginfo_->team_).wait();
+    }
+    else { abort(); }
+#else
+    MPI_Allreduce(sbuf, rbuf, count, mpi_type<T>(), mpi_op(op), pginfo_->mpi_comm_);
+#endif
+  }
+
+  template<typename T>
+  void allreduce(const T* sbuf, T* rbuf, int count, ReduceOp op) {
+#if defined(USE_UPCXX)
+
+    if(op == ReduceOp::min) {
+      upcxx::reduce_all(sbuf, rbuf, count, [](const T& a, const T& b){ return std::abs(a) < std::abs(b) ? a : b; }, *pginfo_->team_).wait();
+    }
+    else if(op == ReduceOp::max) {
+      upcxx::reduce_all(sbuf, rbuf, count, [](const T& a, const T& b){ return std::abs(a) > std::abs(b) ? a : b; }, *pginfo_->team_).wait();
+    }
+    else if(op == ReduceOp::sum) {
+      upcxx::reduce_all(sbuf, rbuf, count, [](const T& a, const T& b){ return a + b; }, *pginfo_->team_).wait();
     }
     else { abort(); }
 #else

--- a/tests/tamm/Test_Mult_Ops.cpp
+++ b/tests/tamm/Test_Mult_Ops.cpp
@@ -217,6 +217,8 @@ void test_4_dim_mult_op(Scheduler& sch, size_t N, Tile tilesize, ExecutionHW ex_
       std::cout << "4-D Tensor contraction (C=RxR) with " << N << " indices tiled with " << tilesize
                 << " : " << mult_time << std::endl;
 
+    CT c_norm = tamm::norm(C);
+
     sch.deallocate(A, B, C).execute();
   }
 


### PR DESCRIPTION
If `tamm::norm(C)` is called with `C` of type `Tensor<std::complex<T>` AND `USE_UPCXX` is defined, then `static_assert(!fast_demanded, "upcxx::op_fast_*** cannot be applied to this datatype.");` fails. This is because although `std::complex<double>` is _TriviallyCopyable_ (thus _TriviallySerializable_)  its `std::is_arithmetic<std::complex<double>>::value` is false which means the built-in `upcxx::opt_fast_*` operators are not valid for this type.

The solution is to pass a user-defined operation (a lambda will work) as the `op` argument in `upcxx::reduce_{one,all}`. And to select the right variant at compile-time, we can use SFINAE via `enable_if`.