### PR TITLE
linf_norm and min,max_element

### DIFF
--- a/src/tamm/proc_group.hpp
+++ b/src/tamm/proc_group.hpp
@@ -564,6 +564,26 @@ public:
     else if(op == ReduceOp::sum) {
       upcxx::reduce_all(sbuf, rbuf, count, upcxx::op_fast_add, *pginfo_->team_).wait();
     }
+    else if(op == ReduceOp::minloc) {
+      auto pair                  = std::make_pair(sbuf[0], sbuf[1]);
+      std::tie(rbuf[0], rbuf[1]) = upcxx::reduce_all(
+                                     pair,
+                                     [](const decltype(pair)& a, const decltype(pair)& b) {
+                                       return a.first < b.first ? a : b;
+                                     },
+                                     *pginfo_->team_)
+                                     .wait();
+    }
+    else if(op == ReduceOp::maxloc) {
+      auto pair                  = std::make_pair(sbuf[0], sbuf[1]);
+      std::tie(rbuf[0], rbuf[1]) = upcxx::reduce_all(
+                                     pair,
+                                     [](const decltype(pair)& a, const decltype(pair)& b) {
+                                       return a.first > b.first ? a : b;
+                                     },
+                                     *pginfo_->team_)
+                                     .wait();
+    }
     else { abort(); }
 #else
     auto mpidtype = mpi_type<T>();

--- a/tests/tamm/Test_Utils.cpp
+++ b/tests/tamm/Test_Utils.cpp
@@ -79,11 +79,9 @@ void test_utils(Scheduler& sch, ExecutionHW ex_hw) {
   T  b_norm = tamm::norm(B);
   CT c_norm = tamm::norm(C);
 
-// linf_norm
-#if !defined(USE_UPCXX)
+  // linf_norm
   T  b_linf_norm = tamm::linf_norm(B);
   CT c_linf_norm = tamm::linf_norm(C);
-#endif
 
   // sqrt
   Tensor<T>  b_sqrt = tamm::sqrt(B);
@@ -131,11 +129,9 @@ void test_utils(Scheduler& sch, ExecutionHW ex_hw) {
   // tamm::random_ip(A);
   tamm::random_ip(B);
 
-// max_element,min_element
-#if !defined(USE_UPCXX)
+  // max_element,min_element
   auto [bmaxval, bmaxblockid, bmaxcoord] = tamm::max_element(B);
   auto [bminval, bminblockid, bmincoord] = tamm::min_element(B);
-#endif
 
   // update_tensor_val
   const T                   val_t = 42.0;


### PR DESCRIPTION
Enabled `tamm::linf_norm(...)`and `min,max_element(...)` using UPC++ (minloc and maxloc operations as lambdas).