### PR TITLE
UPC++ support for rank 2 tensors

### DIFF
--- a/src/tamm/proc_group.hpp
+++ b/src/tamm/proc_group.hpp
@@ -437,13 +437,13 @@ public:
 #if defined(USE_UPCXX)
     if(op == ReduceOp::min) {
       upcxx::reduce_one(
-        buf, &result, 1, [](const T& a, const T& b) { return std::abs(a) < std::abs(b) ? a : b; },
+        buf, &result, 1, [](const T& a, const T& b) { return std::norm(a) < std::norm(b) ? a : b; },
         root, *pginfo_->team_)
         .wait();
     }
     else if(op == ReduceOp::max) {
       upcxx::reduce_one(
-        buf, &result, 1, [](const T& a, const T& b) { return std::abs(a) > std::abs(b) ? a : b; },
+        buf, &result, 1, [](const T& a, const T& b) { return std::norm(a) > std::norm(b) ? a : b; },
         root, *pginfo_->team_)
         .wait();
     }
@@ -482,14 +482,16 @@ public:
 #if defined(USE_UPCXX)
     if(op == ReduceOp::min) {
       upcxx::reduce_one(
-        sbuf, rbuf, count, [](const T& a, const T& b) { return std::abs(a) < std::abs(b) ? a : b; },
-        root, *pginfo_->team_)
+        sbuf, rbuf, count,
+        [](const T& a, const T& b) { return std::norm(a) < std::norm(b) ? a : b; }, root,
+        *pginfo_->team_)
         .wait();
     }
     else if(op == ReduceOp::max) {
       upcxx::reduce_one(
-        sbuf, rbuf, count, [](const T& a, const T& b) { return std::abs(a) > std::abs(b) ? a : b; },
-        root, *pginfo_->team_)
+        sbuf, rbuf, count,
+        [](const T& a, const T& b) { return std::norm(a) > std::norm(b) ? a : b; }, root,
+        *pginfo_->team_)
         .wait();
     }
     else if(op == ReduceOp::sum) {
@@ -529,13 +531,13 @@ public:
 #if defined(USE_UPCXX)
     if(op == ReduceOp::min) {
       upcxx::reduce_all(
-        buf, &result, 1, [](const T& a, const T& b) { return std::abs(a) < std::abs(b) ? a : b; },
+        buf, &result, 1, [](const T& a, const T& b) { return std::norm(a) < std::norm(b) ? a : b; },
         *pginfo_->team_)
         .wait();
     }
     else if(op == ReduceOp::max) {
       upcxx::reduce_all(
-        buf, &result, 1, [](const T& a, const T& b) { return std::abs(a) > std::abs(b) ? a : b; },
+        buf, &result, 1, [](const T& a, const T& b) { return std::norm(a) > std::norm(b) ? a : b; },
         *pginfo_->team_)
         .wait();
     }
@@ -598,14 +600,14 @@ public:
 
     if(op == ReduceOp::min) {
       upcxx::reduce_all(
-        sbuf, rbuf, count, [](const T& a, const T& b) { return std::abs(a) < std::abs(b) ? a : b; },
-        *pginfo_->team_)
+        sbuf, rbuf, count,
+        [](const T& a, const T& b) { return std::norm(a) < std::norm(b) ? a : b; }, *pginfo_->team_)
         .wait();
     }
     else if(op == ReduceOp::max) {
       upcxx::reduce_all(
-        sbuf, rbuf, count, [](const T& a, const T& b) { return std::abs(a) > std::abs(b) ? a : b; },
-        *pginfo_->team_)
+        sbuf, rbuf, count,
+        [](const T& a, const T& b) { return std::norm(a) > std::norm(b) ? a : b; }, *pginfo_->team_)
         .wait();
     }
     else if(op == ReduceOp::sum) {

--- a/src/tamm/tamm_utils.hpp
+++ b/src/tamm/tamm_utils.hpp
@@ -2956,8 +2956,10 @@ Tensor<TensorType> tensor_block(Tensor<TensorType> tensor, std::vector<int64_t> 
                                 std::vector<int64_t> hi, std::vector<int> permute = {}) {
   const int ndims = tensor.num_modes();
 
+#if defined(USE_UPCXX)
   // Only works for 2-D - for now
   EXPECTS(ndims == 2);
+#endif
   EXPECTS(tensor.kind() == TensorBase::TensorKind::dense);
   EXPECTS(tensor.distribution().kind() == DistributionKind::dense);
 

--- a/src/tamm/tensor.hpp
+++ b/src/tamm/tensor.hpp
@@ -276,7 +276,7 @@ public:
   }
 #else
   /**
-   * Access the underying global array
+   * Access the underlying global array
    * @return Handle to underlying global array
    */
   int ga_handle() { return impl_->ga_handle(); }

--- a/tests/tamm/Test_Utils.cpp
+++ b/tests/tamm/Test_Utils.cpp
@@ -119,9 +119,9 @@ void test_utils(Scheduler& sch, ExecutionHW ex_hw) {
   sch.deallocate(b_einverse, c_einverse).execute();
 
   // scale, scale_ip
-  Tensor<T>  b_scale = tamm::scale(B, 2.0);
+  Tensor<T>  b_scale = tamm::scale(B, static_cast<T>(2.0));
   Tensor<CT> c_scale = tamm::scale(C, (CT) 2.0);
-  tamm::scale_ip(b_scale, 2.0);
+  tamm::scale_ip(b_scale, static_cast<T>(2.0));
   tamm::scale_ip(c_scale, (CT) 2.0);
   sch.deallocate(b_scale, c_scale).execute();
 
@@ -180,6 +180,50 @@ void test_utils(Scheduler& sch, ExecutionHW ex_hw) {
   tamm::retile_tamm_tensor(B, b_ret);
   tamm::retile_tamm_tensor(C, c_ret);
   sch.deallocate(b_ret, c_ret).execute();
+
+#else // Only for rank 2 tensors
+  TiledIndexSpace tis_1{IndexSpace{range(N)}, tilesize};
+  auto [ii, jj] = tis_1.labels<2>("all");
+
+  Tensor<T> B2{ii, jj};
+  sch.allocate(B2).execute();
+  tamm::random_ip(B2);
+
+  Tensor<CT> C2{ii, jj};
+  sch.allocate(C2).execute();
+  tamm::random_ip(C2);
+
+  // to_dense_tensor
+  Tensor<T>  b_dens = tamm::to_dense_tensor(ec_dense, B2);
+  Tensor<CT> c_dens = tamm::to_dense_tensor(ec_dense, C2);
+
+  // get_tensor_element
+  T  b_dens_val = tamm::get_tensor_element(b_dens, {0, 0});
+  CT c_dens_val = tamm::get_tensor_element(c_dens, {0, 0});
+
+  // tensor_block
+  Tensor<T>  b_block = tamm::tensor_block(b_dens, {0, 0}, {N / 2, N / 2});
+  Tensor<CT> c_block = tamm::tensor_block(c_dens, {0, 0}, {N / 2, N / 2});
+
+  sch.deallocate(b_dens, c_dens).execute();
+  sch.deallocate(b_block, c_block).execute();
+
+  // redistribute_tensor
+  TiledIndexSpace    tis_red{IndexSpace{range(N)}, N / 2};
+  TiledIndexSpaceVec tis_red_vec{tis_red, tis_red};
+  Tensor<T>          b_red = tamm::redistribute_tensor<T>(B2, tis_red_vec);
+  Tensor<CT>         c_red = tamm::redistribute_tensor<CT>(C2, tis_red_vec);
+  sch.deallocate(b_red, c_red).execute();
+
+  // retile_tamm_tensor
+  Tensor<T>  b_ret{tis_red, tis_red};
+  Tensor<CT> c_ret{tis_red, tis_red};
+  sch.allocate(b_ret, c_ret).execute();
+  tamm::retile_tamm_tensor(B, b_ret);
+  tamm::retile_tamm_tensor(C, c_ret);
+  sch.deallocate(b_ret, c_ret).execute();
+
+  sch.deallocate(B2, C2).execute();
 #endif
 
   sch.deallocate(A, B, C).execute();


### PR DESCRIPTION
This PR is about completing the support for rank 2 tensors when using UPC++. There's still a lot of work to be done, but this PR's changes should satisfy the routines in `Test_Utils.cpp` without issues.