### PR TITLE
Extended support for dense tensors up to rank-4

### DIFF
--- a/src/tamm/ga_over_upcxx.hpp
+++ b/src/tamm/ga_over_upcxx.hpp
@@ -332,30 +332,19 @@ public:
     rank   = t.rank_me();
     nranks = t.rank_n();
 
-    if(_ndims == 2 || _ndims == 3) {
-      /*
-       * Hacky, because the APIs below only accept 4 dimensional
-       * indices so it leads to an inconsistency between construction
-       * and access. But just to get things working.
-       */
+    if(_ndims >= 1 && _ndims <= 4) {
+
       memcpy(dims, _dims, _ndims * sizeof(dims[0]));
       memcpy(chunk_size, _chunk_size, _ndims * sizeof(chunk_size[0]));
-      if(_ndims == 2) {
-        dims[2]       = 1;
-        chunk_size[2] = 1;
+
+      for (int i = _ndims; i < 4; ++i) {
+        dims[i] = 1;
+        chunk_size[i] = 1;
       }
-      dims[3]       = 1;
-      chunk_size[3] = 1;
-    }
-    else if(_ndims == 4) {
-      memcpy(dims, _dims, 4 * sizeof(dims[0]));
-      memcpy(chunk_size, _chunk_size, 4 * sizeof(chunk_size[0]));
     }
     else {
       fprintf(stderr,
-              "ga_over_upcxx only supports 2,3,4D tensors, got "
-              "_ndims=%d\n",
-              _ndims);
+              "ga_over_upcxx only supports 1,2,3,4D tensors, got _ndims=%d\n", _ndims);
       abort();
     }
 
@@ -373,7 +362,7 @@ public:
       // Find the largest chunks per dim
       int64_t most_chunks_per_dim     = chunks_per_dim[0];
       int     dim_most_chunks_per_dim = 0;
-      for(int i = 1; i < 4; i++) {
+      for(int i = 0; i < 4; i++) {
         if(chunks_per_dim[i] > most_chunks_per_dim) {
           most_chunks_per_dim     = chunks_per_dim[i];
           dim_most_chunks_per_dim = i;
@@ -584,7 +573,7 @@ public:
     if(in_dims[0] != (high0 - low0 + 1) || in_dims[1] != (high1 - low1 + 1) ||
        in_dims[2] != (high2 - low2 + 1) || in_dims[3] != (high3 - low3 + 1)) {
       fprintf(stderr,
-              "ga_over_upcxx::get size mismatch (%ld %ld "
+              "ga_over_upcxx::put size mismatch (%ld %ld "
               "%ld %ld) (%ld %ld %ld %ld)\n",
               in_dims[0], in_dims[1], in_dims[2], in_dims[3], high0 - low0 + 1, high1 - low1 + 1,
               high2 - low2 + 1, high3 - low3 + 1);
@@ -608,8 +597,7 @@ public:
                                    j * chunks_per_dim[2] * chunks_per_dim[3] +
                                    k * chunks_per_dim[3] + l;
             ga_over_upcxx_chunk<T>* chunk = all_chunks[chunk_offset];
-            fut                           = upcxx::when_all(
-                                        fut, chunk->put_any(low0, low1, low2, low3, high0, high1, high2, high3, in));
+            fut                           = upcxx::when_all(fut, chunk->put_any(low0, low1, low2, low3, high0, high1, high2, high3, in));
           }
         }
       }

--- a/src/tamm/ga_over_upcxx.hpp
+++ b/src/tamm/ga_over_upcxx.hpp
@@ -333,18 +333,16 @@ public:
     nranks = t.rank_n();
 
     if(_ndims >= 1 && _ndims <= 4) {
-
       memcpy(dims, _dims, _ndims * sizeof(dims[0]));
       memcpy(chunk_size, _chunk_size, _ndims * sizeof(chunk_size[0]));
 
-      for (int i = _ndims; i < 4; ++i) {
-        dims[i] = 1;
+      for(int i = _ndims; i < 4; ++i) {
+        dims[i]       = 1;
         chunk_size[i] = 1;
       }
     }
     else {
-      fprintf(stderr,
-              "ga_over_upcxx only supports 1,2,3,4D tensors, got _ndims=%d\n", _ndims);
+      fprintf(stderr, "ga_over_upcxx only supports 1,2,3,4D tensors, got _ndims=%d\n", _ndims);
       abort();
     }
 
@@ -597,7 +595,8 @@ public:
                                    j * chunks_per_dim[2] * chunks_per_dim[3] +
                                    k * chunks_per_dim[3] + l;
             ga_over_upcxx_chunk<T>* chunk = all_chunks[chunk_offset];
-            fut                           = upcxx::when_all(fut, chunk->put_any(low0, low1, low2, low3, high0, high1, high2, high3, in));
+            fut                           = upcxx::when_all(
+                                        fut, chunk->put_any(low0, low1, low2, low3, high0, high1, high2, high3, in));
           }
         }
       }

--- a/src/tamm/tamm_utils.hpp
+++ b/src/tamm/tamm_utils.hpp
@@ -73,13 +73,13 @@ double compute_tensor_size(const Tensor<T>& tensor) {
 template<typename T>
 void print_tensor(const Tensor<T>& tensor, std::string filename = "") {
   std::stringstream tstring;
-  auto              lt = tensor();
+  auto lt = tensor();
 
   auto nz_check = [=](const T val) {
     if constexpr(tamm::internal::is_complex_v<T>) {
-      if(val.real() > 0.0000000000001 || val.real() < -0.0000000000001) return true;
+      if(val.real() > 1e-12 || val.real() < -1e-12) return true;
     }
-    else if(val > 0.0000000000001 || val < -0.0000000000001) return true;
+    else if(val > 1e-12 || val < -1e-12) return true;
     return false;
   };
 
@@ -712,25 +712,22 @@ ga_over_upcxx<TensorType>* tamm_to_ga(ExecutionContext& ec, Tensor<TensorType>& 
 int tamm_to_ga(ExecutionContext& ec, Tensor<TensorType>& tensor)
 #endif
 {
-  int                  ndims = tensor.num_modes();
-  std::vector<int64_t> dims;
+  int ndims = tensor.num_modes();
+  std::vector<int64_t> dims(4, 1), chnks(4, -1);
+  auto tis = tensor.tiled_index_spaces();
+  
+  for(int i = 0; i < ndims; ++i) {
+    dims[i] = tis[i].index_space().num_indices();
+  }
 
-  for(auto tis: tensor.tiled_index_spaces()) dims.push_back(tis.index_space().num_indices());
-
-  std::vector<int64_t> chnks(ndims, -1);
 #if defined(USE_UPCXX)
   if(ndims > 4) {
     fprintf(stderr, "Invalid ndims=%d, only support up to 4\n", ndims);
     abort();
   }
-  // pad out to 3 dimensions if we're less
-  for(int i = ndims; i < 4; i++) {
-    dims.push_back(1);
-    chnks.push_back(-1);
-  }
 
   ga_over_upcxx<TensorType>* ga_tens =
-    new ga_over_upcxx<TensorType>(4, &dims[0], &chnks[0], upcxx::world());
+    new ga_over_upcxx<TensorType>(4, dims.data(), chnks.data(), upcxx::world());
 #else
   int ga_pg_default = GA_Pgroup_get_default();
   GA_Pgroup_set_default(ec.pg().ga_pg());
@@ -750,8 +747,8 @@ int tamm_to_ga(ExecutionContext& ec, Tensor<TensorType>& tensor)
     const tamm::TAMM_SIZE dsize = tensor.block_size(blockid);
 
 #if defined(USE_UPCXX)
-    std::vector<int64_t> lo(4), hi(4);
-    std::vector<int64_t> ld(4);
+    std::vector<int64_t> lo(4, 0), hi(4, 0);
+    std::vector<int64_t> ld(4, 1);
 #else
     std::vector<int64_t> lo(ndims), hi(ndims);
     std::vector<int64_t> ld(ndims - 1);
@@ -759,13 +756,9 @@ int tamm_to_ga(ExecutionContext& ec, Tensor<TensorType>& tensor)
 
     for(size_t i = 0; i < ndims; i++) lo[i] = cd_ncast<size_t>(block_offset[i]);
     for(size_t i = 0; i < ndims; i++) hi[i] = cd_ncast<size_t>(block_offset[i] + block_dims[i] - 1);
+
 #if defined(USE_UPCXX)
     for(size_t i = 0; i < ndims; i++) ld[i] = cd_ncast<size_t>(block_dims[i]);
-    for(size_t i = ndims; i < 4; i++) {
-      lo[i] = 0;
-      hi[i] = 0;
-      ld[i] = 1;
-    }
 #else
     for(size_t i = 1; i < ndims; i++) ld[i - 1] = cd_ncast<size_t>(block_dims[i]);
 #endif
@@ -774,7 +767,7 @@ int tamm_to_ga(ExecutionContext& ec, Tensor<TensorType>& tensor)
     tensor.get(blockid, sbuf);
 
 #if defined(USE_UPCXX)
-    ga_tens->put(lo[0], lo[1], lo[2], lo[3], hi[0], hi[1], hi[2], hi[3], &sbuf[0], &ld[0]);
+    ga_tens->put(lo[0], lo[1], lo[2], lo[3], hi[0], hi[1], hi[2], hi[3], sbuf.data(), ld.data());
 #else
     NGA_Put64(ga_tens, &lo[0], &hi[0], &sbuf[0], &ld[0]);
 #endif
@@ -784,6 +777,7 @@ int tamm_to_ga(ExecutionContext& ec, Tensor<TensorType>& tensor)
 
   return ga_tens;
 }
+
 
 template<typename T>
 hid_t get_hdf5_dt() {
@@ -1285,8 +1279,8 @@ void ga_to_tamm(ExecutionContext& ec, Tensor<TensorType>& tensor,
     const tamm::TAMM_SIZE dsize = tensor.block_size(blockid);
 
 #if defined(USE_UPCXX)
-    std::vector<int64_t> lo(4), hi(4);
-    std::vector<int64_t> ld(4);
+    std::vector<int64_t> lo(4, 0), hi(4, 0);
+    std::vector<int64_t> ld(4, 1);
 #else
     std::vector<int64_t> lo(ndims), hi(ndims);
     std::vector<int64_t> ld(ndims - 1);
@@ -1294,20 +1288,16 @@ void ga_to_tamm(ExecutionContext& ec, Tensor<TensorType>& tensor,
 
     for(size_t i = 0; i < ndims; i++) lo[i] = cd_ncast<size_t>(block_offset[i]);
     for(size_t i = 0; i < ndims; i++) hi[i] = cd_ncast<size_t>(block_offset[i] + block_dims[i] - 1);
+
 #if defined(USE_UPCXX)
     for(size_t i = 0; i < ndims; i++) ld[i] = cd_ncast<size_t>(block_dims[i]);
-    for(size_t i = ndims; i < 4; i++) {
-      lo[i] = 0;
-      hi[i] = 0;
-      ld[i] = 1;
-    }
 #else
     for(size_t i = 1; i < ndims; i++) ld[i - 1] = cd_ncast<size_t>(block_dims[i]);
 #endif
 
     std::vector<TensorType> sbuf(dsize);
 #if defined(USE_UPCXX)
-    ga_tens->get(lo[0], lo[1], lo[2], lo[3], hi[0], hi[1], hi[2], hi[3], &sbuf[0], &ld[0]);
+    ga_tens->get(lo[0], lo[1], lo[2], lo[3], hi[0], hi[1], hi[2], hi[3], sbuf.data(), ld.data());
 #else
     NGA_Get64(ga_tens, &lo[0], &hi[0], &sbuf[0], &ld[0]);
 #endif
@@ -2838,7 +2828,7 @@ void to_block_cyclic_tensor(Tensor<TensorType> tensor, Tensor<TensorType> bc_ten
     std::vector<TensorType> sbuf(dsize);
     tensor.get(blockid, sbuf);
 #if defined(USE_UPCXX)
-    bc_tensor.put_raw(lo, hi, &sbuf[0], &ld);
+    bc_tensor.put_raw(lo, hi, sbuf.data());
 #else
     NGA_Put64(ga_tens, &lo[0], &hi[0], &sbuf[0], &ld[0]);
 #endif
@@ -2885,7 +2875,7 @@ void from_block_cyclic_tensor(Tensor<TensorType> bc_tensor, Tensor<TensorType> t
 
     std::vector<TensorType> sbuf(dsize);
 #if defined(USE_UPCXX)
-    bc_tensor.get_raw(lo, hi, &sbuf[0], &ld);
+    bc_tensor.get_raw(lo, hi, sbuf.data());
 #else
     NGA_Get64(ga_tens, &lo[0], &hi[0], &sbuf[0], &ld[0]);
 #endif
@@ -2956,10 +2946,6 @@ Tensor<TensorType> tensor_block(Tensor<TensorType> tensor, std::vector<int64_t> 
                                 std::vector<int64_t> hi, std::vector<int> permute = {}) {
   const int ndims = tensor.num_modes();
 
-#if defined(USE_UPCXX)
-  // Only works for 2-D - for now
-  EXPECTS(ndims == 2);
-#endif
   EXPECTS(tensor.kind() == TensorBase::TensorKind::dense);
   EXPECTS(tensor.distribution().kind() == DistributionKind::dense);
 
@@ -2992,20 +2978,31 @@ Tensor<TensorType> tensor_block(Tensor<TensorType> tensor, std::vector<int64_t> 
   Tensor<TensorType>::allocate(&ec, btensor);
 
 #if defined(USE_UPCXX)
-  std::vector<int64_t> chnks(ndims + 2, -1), dims(ndims + 2, 1), ld(ndims + 2, 1);
-  dims[0] = tis[0].index_space().num_indices();
-  dims[1] = tis[1].index_space().num_indices();
-  lo.push_back(0), lo.push_back(0), hi.push_back(0), hi.push_back(0);
-  ld[0] = hi[0] - lo[0] + 1;
-  ld[1] = hi[1] - lo[1] + 1;
+  EXPECTS(ndims >= 1 && ndims <= 4);
+
+  std::vector<int64_t> chnks(ndims, -1), dims(ndims, 1), ld(4, 1);
+
+  for(int i = 0; i < ndims; ++i) {
+    dims[i] = tis[i].index_space().num_indices();
+    ld[i] = hi[i] - lo[i] + 1;
+  }
+
   std::vector<TensorType>    sbuf(btensor.size());
-  ga_over_upcxx<TensorType>* ga_stensor =
-    new ga_over_upcxx<TensorType>(ndims + 2, dims.data(), chnks.data(), upcxx::world());
-  tensor.get_raw(lo.data(), hi.data(), sbuf.data(), ld.data());
-  ga_stensor->put(0, 0, 0, 0, ld[0] - 1, ld[1] - 1, 0, 0, sbuf.data(), ld.data());
+  ga_over_upcxx<TensorType>* ga_stensor = new ga_over_upcxx<TensorType>(ndims, dims.data(), chnks.data(), upcxx::world());
+
+  // Pad to 4D
+  for (int i = ndims; i < 4; ++i) {
+    lo.insert(lo.begin(), 0);
+    hi.insert(hi.begin(), 0);
+  }
+
+  tensor.get_raw_one(lo.data(), hi.data(), sbuf.data());
+
+  ga_stensor->put(0, 0, 0, 0, ld[0]-1, ld[1]-1, ld[2]-1, ld[3]-1, sbuf.data(), ld.data());
   ga_to_tamm(ec, btensor, ga_stensor);
   ga_stensor->destroy();
 #else
+
   int btensor_gah = btensor.ga_handle();
   int tensor_gah = tensor.ga_handle();
 
@@ -3163,20 +3160,29 @@ TensorType get_tensor_element(Tensor<TensorType> tensor, std::vector<int64_t> in
   const int ndims = tensor.num_modes();
   EXPECTS(tensor.kind() == TensorBase::TensorKind::dense);
 
-  TensorType val{};
+  TensorType val {};
 
+#if defined(USE_UPCXX)
+  EXPECTS(ndims >= 1 && ndims <= 4);
+
+  std::vector<int64_t> lo(4, 0), hi(4, 0);
+
+  for (int i = 4-ndims, j = 0; i < 4; ++i, ++j) {
+    lo[i] = index_id[j];
+    hi[i] = index_id[j];
+  }
+
+  tensor.get_raw(lo.data(), hi.data(), &val);
+#else
   std::vector<int64_t> lo(ndims), hi(ndims);
-  std::vector<int64_t> ld(ndims - 1, 1);
+  std::vector<int64_t> ld(ndims-1, 1);
 
   for(int i = 0; i < ndims; i++) {
     lo[i] = index_id[i];
     hi[i] = index_id[i];
   }
 
-#if defined(USE_UPCXX)
-  tensor.get_raw(&lo[0], &hi[0], &val, &ld[0]);
-#else
-  NGA_Get64(tensor.ga_handle(), &lo[0], &hi[0], &val, &ld[0]);
+  NGA_Get64(tensor.ga_handle(), lo.data(), hi.data(), &val, ld.data());
 #endif
 
   return val;
@@ -3189,29 +3195,28 @@ TensorType get_tensor_element(Tensor<TensorType> tensor, std::vector<int64_t> in
  * @param [in] tensor input Tensor object
  */
 template<typename T>
-void print_dense_tensor(const Tensor<T>& tensor, std::function<bool(std::vector<size_t>)> func,
-                        std::string filename = "", bool append = false) {
-  auto              lt    = tensor();
-  int               ndims = tensor.num_modes();
-  ExecutionContext& ec    = get_ec(lt);
+void print_dense_tensor(const Tensor<T>& tensor, std::function<bool(std::vector<size_t>)> func, std::string filename = "", bool append = false) {
+  auto           lt    = tensor();
+  int            ndims = tensor.num_modes();
+  ExecutionContext& ec = get_ec(lt);
 
   auto nz_check = [=](const T val) {
     if constexpr(tamm::internal::is_complex_v<T>) {
-      if(val.real() > 0.0000000000001 || val.real() < -0.0000000000001) return true;
+      if(val.real() > 1e-12 || val.real() < -1e-12) return true;
     }
-    else if(val > 0.0000000000001 || val < -0.0000000000001) return true;
+    else if(val > 1e-12 || val < -1e-12) return true;
     return false;
   };
 
   if(ec.pg().rank() == 0) {
     std::stringstream tstring;
-    EXPECTS(ndims > 0 && ndims <= 4);
-    std::vector<int64_t> dims;
-    for(auto tis: tensor.tiled_index_spaces()) dims.push_back(tis.index_space().num_indices());
+    EXPECTS(ndims >= 1 && ndims <= 4);
 
     for(auto it: tensor.loop_nest()) {
       auto blockid = internal::translate_blockid(it, lt);
+
       if(!tensor.is_non_zero(blockid)) continue;
+
       TAMM_SIZE      size = tensor.block_size(blockid);
       std::vector<T> buf(size);
       tensor.get(blockid, buf);
@@ -3223,14 +3228,14 @@ void print_dense_tensor(const Tensor<T>& tensor, std::function<bool(std::vector<
       size_t c = 0;
       if(ndims == 1) {
         for(size_t i = block_offset[0]; i < block_offset[0] + block_dims[0]; i++, c++) {
-          if(func({i}) && nz_check(buf[c])) tstring << i + 1 << "   " << buf[c] << std::endl;
+          if(func({i}) && nz_check(buf[c])) tstring << i << "   " << buf[c] << std::endl;
         }
       }
       else if(ndims == 2) {
         for(size_t i = block_offset[0]; i < block_offset[0] + block_dims[0]; i++) {
           for(size_t j = block_offset[1]; j < block_offset[1] + block_dims[1]; j++, c++) {
             if(func({i, j}) && nz_check(buf[c]))
-              tstring << i + 1 << "   " << j + 1 << "   " << buf[c] << std::endl;
+              tstring << i << "   " << j << "   " << buf[c] << std::endl;
           }
         }
       }
@@ -3239,7 +3244,7 @@ void print_dense_tensor(const Tensor<T>& tensor, std::function<bool(std::vector<
           for(size_t j = block_offset[1]; j < block_offset[1] + block_dims[1]; j++) {
             for(size_t k = block_offset[2]; k < block_offset[2] + block_dims[2]; k++, c++) {
               if(func({i, j, k}) && nz_check(buf[c]))
-                tstring << i + 1 << "   " << j + 1 << "   " << k + 1 << "   " << buf[c]
+                tstring << i << "   " << j << "   " << k << "   " << buf[c]
                         << std::endl;
             }
           }
@@ -3251,7 +3256,7 @@ void print_dense_tensor(const Tensor<T>& tensor, std::function<bool(std::vector<
             for(size_t k = block_offset[2]; k < block_offset[2] + block_dims[2]; k++) {
               for(size_t l = block_offset[3]; l < block_offset[3] + block_dims[3]; l++, c++) {
                 if(func({i, j, k, l}) && nz_check(buf[c]))
-                  tstring << i + 1 << "   " << j + 1 << "   " << k + 1 << "   " << l + 1 << "   "
+                  tstring << i << "   " << j << "   " << k << "   " << l << "   "
                           << buf[c] << std::endl;
               }
             }

--- a/src/tamm/tamm_utils.hpp
+++ b/src/tamm/tamm_utils.hpp
@@ -73,7 +73,7 @@ double compute_tensor_size(const Tensor<T>& tensor) {
 template<typename T>
 void print_tensor(const Tensor<T>& tensor, std::string filename = "") {
   std::stringstream tstring;
-  auto lt = tensor();
+  auto              lt = tensor();
 
   auto nz_check = [=](const T val) {
     if constexpr(tamm::internal::is_complex_v<T>) {
@@ -712,13 +712,11 @@ ga_over_upcxx<TensorType>* tamm_to_ga(ExecutionContext& ec, Tensor<TensorType>& 
 int tamm_to_ga(ExecutionContext& ec, Tensor<TensorType>& tensor)
 #endif
 {
-  int ndims = tensor.num_modes();
+  int                  ndims = tensor.num_modes();
   std::vector<int64_t> dims(4, 1), chnks(4, -1);
-  auto tis = tensor.tiled_index_spaces();
-  
-  for(int i = 0; i < ndims; ++i) {
-    dims[i] = tis[i].index_space().num_indices();
-  }
+  auto                 tis = tensor.tiled_index_spaces();
+
+  for(int i = 0; i < ndims; ++i) { dims[i] = tis[i].index_space().num_indices(); }
 
 #if defined(USE_UPCXX)
   if(ndims > 4) {
@@ -777,7 +775,6 @@ int tamm_to_ga(ExecutionContext& ec, Tensor<TensorType>& tensor)
 
   return ga_tens;
 }
-
 
 template<typename T>
 hid_t get_hdf5_dt() {
@@ -2984,21 +2981,22 @@ Tensor<TensorType> tensor_block(Tensor<TensorType> tensor, std::vector<int64_t> 
 
   for(int i = 0; i < ndims; ++i) {
     dims[i] = tis[i].index_space().num_indices();
-    ld[i] = hi[i] - lo[i] + 1;
+    ld[i]   = hi[i] - lo[i] + 1;
   }
 
   std::vector<TensorType>    sbuf(btensor.size());
-  ga_over_upcxx<TensorType>* ga_stensor = new ga_over_upcxx<TensorType>(ndims, dims.data(), chnks.data(), upcxx::world());
+  ga_over_upcxx<TensorType>* ga_stensor =
+    new ga_over_upcxx<TensorType>(ndims, dims.data(), chnks.data(), upcxx::world());
 
   // Pad to 4D
-  for (int i = ndims; i < 4; ++i) {
+  for(int i = ndims; i < 4; ++i) {
     lo.insert(lo.begin(), 0);
     hi.insert(hi.begin(), 0);
   }
 
   tensor.get_raw_one(lo.data(), hi.data(), sbuf.data());
 
-  ga_stensor->put(0, 0, 0, 0, ld[0]-1, ld[1]-1, ld[2]-1, ld[3]-1, sbuf.data(), ld.data());
+  ga_stensor->put(0, 0, 0, 0, ld[0] - 1, ld[1] - 1, ld[2] - 1, ld[3] - 1, sbuf.data(), ld.data());
   ga_to_tamm(ec, btensor, ga_stensor);
   ga_stensor->destroy();
 #else
@@ -3160,14 +3158,14 @@ TensorType get_tensor_element(Tensor<TensorType> tensor, std::vector<int64_t> in
   const int ndims = tensor.num_modes();
   EXPECTS(tensor.kind() == TensorBase::TensorKind::dense);
 
-  TensorType val {};
+  TensorType val{};
 
 #if defined(USE_UPCXX)
   EXPECTS(ndims >= 1 && ndims <= 4);
 
   std::vector<int64_t> lo(4, 0), hi(4, 0);
 
-  for (int i = 4-ndims, j = 0; i < 4; ++i, ++j) {
+  for(int i = 4 - ndims, j = 0; i < 4; ++i, ++j) {
     lo[i] = index_id[j];
     hi[i] = index_id[j];
   }
@@ -3175,7 +3173,7 @@ TensorType get_tensor_element(Tensor<TensorType> tensor, std::vector<int64_t> in
   tensor.get_raw(lo.data(), hi.data(), &val);
 #else
   std::vector<int64_t> lo(ndims), hi(ndims);
-  std::vector<int64_t> ld(ndims-1, 1);
+  std::vector<int64_t> ld(ndims - 1, 1);
 
   for(int i = 0; i < ndims; i++) {
     lo[i] = index_id[i];
@@ -3195,10 +3193,11 @@ TensorType get_tensor_element(Tensor<TensorType> tensor, std::vector<int64_t> in
  * @param [in] tensor input Tensor object
  */
 template<typename T>
-void print_dense_tensor(const Tensor<T>& tensor, std::function<bool(std::vector<size_t>)> func, std::string filename = "", bool append = false) {
-  auto           lt    = tensor();
-  int            ndims = tensor.num_modes();
-  ExecutionContext& ec = get_ec(lt);
+void print_dense_tensor(const Tensor<T>& tensor, std::function<bool(std::vector<size_t>)> func,
+                        std::string filename = "", bool append = false) {
+  auto              lt    = tensor();
+  int               ndims = tensor.num_modes();
+  ExecutionContext& ec    = get_ec(lt);
 
   auto nz_check = [=](const T val) {
     if constexpr(tamm::internal::is_complex_v<T>) {
@@ -3228,14 +3227,14 @@ void print_dense_tensor(const Tensor<T>& tensor, std::function<bool(std::vector<
       size_t c = 0;
       if(ndims == 1) {
         for(size_t i = block_offset[0]; i < block_offset[0] + block_dims[0]; i++, c++) {
-          if(func({i}) && nz_check(buf[c])) tstring << i << "   " << buf[c] << std::endl;
+          if(func({i}) && nz_check(buf[c])) tstring << i + 1 << "   " << buf[c] << std::endl;
         }
       }
       else if(ndims == 2) {
         for(size_t i = block_offset[0]; i < block_offset[0] + block_dims[0]; i++) {
           for(size_t j = block_offset[1]; j < block_offset[1] + block_dims[1]; j++, c++) {
             if(func({i, j}) && nz_check(buf[c]))
-              tstring << i << "   " << j << "   " << buf[c] << std::endl;
+              tstring << i + 1 << "   " << j + 1 << "   " << buf[c] << std::endl;
           }
         }
       }
@@ -3244,7 +3243,7 @@ void print_dense_tensor(const Tensor<T>& tensor, std::function<bool(std::vector<
           for(size_t j = block_offset[1]; j < block_offset[1] + block_dims[1]; j++) {
             for(size_t k = block_offset[2]; k < block_offset[2] + block_dims[2]; k++, c++) {
               if(func({i, j, k}) && nz_check(buf[c]))
-                tstring << i << "   " << j << "   " << k << "   " << buf[c]
+                tstring << i + 1 << "   " << j + 1 << "   " << k + 1 << "   " << buf[c]
                         << std::endl;
             }
           }
@@ -3256,7 +3255,7 @@ void print_dense_tensor(const Tensor<T>& tensor, std::function<bool(std::vector<
             for(size_t k = block_offset[2]; k < block_offset[2] + block_dims[2]; k++) {
               for(size_t l = block_offset[3]; l < block_offset[3] + block_dims[3]; l++, c++) {
                 if(func({i, j, k, l}) && nz_check(buf[c]))
-                  tstring << i << "   " << j << "   " << k << "   " << l << "   "
+                  tstring << i + 1 << "   " << j + 1 << "   " << k + 1 << "   " << l + 1 << "   "
                           << buf[c] << std::endl;
               }
             }

--- a/src/tamm/tensor.hpp
+++ b/src/tamm/tensor.hpp
@@ -267,12 +267,16 @@ public:
   // Tensor Accessors
 
 #if defined(USE_UPCXX)
-  void put_raw(int64_t* lo, int64_t* hi, void* buf, int64_t* buf_ld) {
-    return impl_->put_raw(lo, hi, buf, buf_ld);
+  void put_raw(int64_t* lo, int64_t* hi, void* buf) {
+    return impl_->put_raw(lo, hi, buf);
   }
 
-  void get_raw(int64_t* lo, int64_t* hi, void* buf, int64_t* buf_ld) {
-    return impl_->get_raw(lo, hi, buf, buf_ld);
+  void get_raw(int64_t* lo, int64_t* hi, void* buf) {
+    return impl_->get_raw(lo, hi, buf);
+  }
+  
+  void get_raw_one(int64_t* lo, int64_t* hi, void* buf) {
+    return impl_->get_raw_one(lo, hi, buf);
   }
 #else
   /**

--- a/src/tamm/tensor.hpp
+++ b/src/tamm/tensor.hpp
@@ -267,17 +267,11 @@ public:
   // Tensor Accessors
 
 #if defined(USE_UPCXX)
-  void put_raw(int64_t* lo, int64_t* hi, void* buf) {
-    return impl_->put_raw(lo, hi, buf);
-  }
+  void put_raw(int64_t* lo, int64_t* hi, void* buf) { return impl_->put_raw(lo, hi, buf); }
 
-  void get_raw(int64_t* lo, int64_t* hi, void* buf) {
-    return impl_->get_raw(lo, hi, buf);
-  }
-  
-  void get_raw_one(int64_t* lo, int64_t* hi, void* buf) {
-    return impl_->get_raw_one(lo, hi, buf);
-  }
+  void get_raw(int64_t* lo, int64_t* hi, void* buf) { return impl_->get_raw(lo, hi, buf); }
+
+  void get_raw_one(int64_t* lo, int64_t* hi, void* buf) { return impl_->get_raw_one(lo, hi, buf); }
 #else
   /**
    * Access the underlying global array

--- a/src/tamm/tensor_impl.hpp
+++ b/src/tamm/tensor_impl.hpp
@@ -1119,8 +1119,7 @@ public:
     int64_t j_offset = lo[1] - t.lo[1];
     int64_t k_offset = lo[2] - t.lo[2];
     int64_t l_offset = lo[3] - t.lo[3];
-    auto ss = t.dim[3]*(k_offset + t.dim[2]*(j_offset + t.dim[1]*i_offset));
-    int64_t tile_offset = l_offset + ss;
+    int64_t tile_offset = l_offset + t.dim[3]*(k_offset + t.dim[2]*(j_offset + t.dim[1]*i_offset));
     upcxx::global_ptr<uint8_t> remote_addr = gptrs_[t.rank] + (t.offset*elem_sz) + (tile_offset*elem_sz);
     auto a = (hi[3]-lo[3]+1);
     auto b = (hi[2]-lo[2]+1);
@@ -1142,8 +1141,7 @@ public:
             int64_t k_offset = k - t.lo[2];
             int64_t l_offset = l - t.lo[3];
             int64_t tile_offset = l_offset + t.dim[3]*(k_offset + t.dim[2]*(j_offset + t.dim[1]*i_offset));
-            upcxx::global_ptr<uint8_t> target = gptrs_[t.rank];
-            upcxx::global_ptr<uint8_t> remote_addr = target + (t.offset * elem_sz) + (tile_offset * elem_sz);
+            upcxx::global_ptr<uint8_t> remote_addr = gptrs_[t.rank] + (t.offset * elem_sz) + (tile_offset * elem_sz);
             uint8_t* local_addr  = ((uint8_t*) buf) + (next++ * elem_sz);
             upcxx::rget(remote_addr, local_addr, elem_sz).wait();
       }

--- a/tests/tamm/Test_Utils.cpp
+++ b/tests/tamm/Test_Utils.cpp
@@ -149,7 +149,6 @@ void test_utils(Scheduler& sch, ExecutionHW ex_hw) {
   Tensor<CT> c_perm = permute_tensor<CT>(C, {1, 3, 2, 0});
   sch.deallocate(b_perm, c_perm).execute();
 
-#if defined(USE_UPCXX)
   // to_dense_tensor
   Tensor<T>  b_dens = tamm::to_dense_tensor(ec_dense, B);
   Tensor<CT> c_dens = tamm::to_dense_tensor(ec_dense, C);
@@ -180,8 +179,6 @@ void test_utils(Scheduler& sch, ExecutionHW ex_hw) {
   tamm::retile_tamm_tensor(C, c_ret);
 
   sch.deallocate(b_ret, c_ret).execute();
-#endif
-
   sch.deallocate(A, B, C).execute();
 }
 


### PR DESCRIPTION
The changes in this PR allows TAMM to manipulate dense tensors up to rank-4 backed by UPC++.
