### PR TITLE
Added handy functions for TAMM/Dense scenarios such as Cholesky app

### DIFF
--- a/src/tamm/tensor.hpp
+++ b/src/tamm/tensor.hpp
@@ -490,6 +490,7 @@ public:
     return impl_->local_element_offsets(i, j, k, l);
   }
 
+#ifdef USE_UPCXX
   std::vector<TensorTile>::const_iterator local_tiles_begin() const {
     return impl_->local_tiles_begin();
   }
@@ -497,6 +498,7 @@ public:
   std::vector<TensorTile>::const_iterator local_tiles_end() const {
     return impl_->local_tiles_end();
   }
+#endif
 
   MemoryRegion* memory_region() const { return impl_->memory_region(); }
 

--- a/src/tamm/tensor.hpp
+++ b/src/tamm/tensor.hpp
@@ -265,8 +265,7 @@ public:
   }
 
   // Tensor Accessors
-
-#if defined(USE_UPCXX)
+#ifdef USE_UPCXX
   void put_raw_contig(int64_t* lo, int64_t* hi, void* buf) {
     return impl_->put_raw_contig(lo, hi, buf);
   }
@@ -477,6 +476,27 @@ public:
   size_t local_buf_size() const { return impl_->local_buf_size(); }
 
   size_t total_buf_size(Proc proc) const { return impl_->total_buf_size(proc); }
+
+  std::vector<int64_t> local_buf_dims() const { return impl_->local_buf_dims(); }
+
+  bool is_local_element(int64_t i, int64_t j, int64_t k, int64_t l) const {
+    return impl_->is_local_element(i, j, k, l);
+  }
+
+  std::vector<int64_t> local_tiles_offsets() const { return impl_->local_tiles_offsets(); }
+
+  std::pair<int64_t, int64_t> local_element_offsets(int64_t i, int64_t j, int64_t k,
+                                                    int64_t l) const {
+    return impl_->local_element_offsets(i, j, k, l);
+  }
+
+  std::vector<TensorTile>::const_iterator local_tiles_begin() const {
+    return impl_->local_tiles_begin();
+  }
+
+  std::vector<TensorTile>::const_iterator local_tiles_end() const {
+    return impl_->local_tiles_end();
+  }
 
   MemoryRegion* memory_region() const { return impl_->memory_region(); }
 

--- a/src/tamm/tensor_impl.hpp
+++ b/src/tamm/tensor_impl.hpp
@@ -476,9 +476,11 @@ public:
     abort();
   }
 
+#ifdef USE_UPCXX
   virtual std::vector<TensorTile>::const_iterator local_tiles_begin() const { abort(); }
 
   virtual std::vector<TensorTile>::const_iterator local_tiles_end() const { abort(); }
+#endif
 
   virtual void put_raw_contig(int64_t* lo, int64_t* hi, void* buf) const { abort(); }
 
@@ -1211,23 +1213,13 @@ public:
 #endif
   }
 
+#ifdef USE_UPCXX
   std::vector<TensorTile>::const_iterator local_tiles_begin() const {
-#ifdef USE_UPCXX
     return local_tiles_.cbegin();
-#else
-    throw std::runtime_error("Function local_tiles_begin not defined for GA backend.");
-#endif
   }
 
-  std::vector<TensorTile>::const_iterator local_tiles_end() const {
-#ifdef USE_UPCXX
-    return local_tiles_.cend();
-#else
-    throw std::runtime_error("Function local_tiles_end not defined for GA backend.");
-#endif
-  }
+  std::vector<TensorTile>::const_iterator local_tiles_end() const { return local_tiles_.cend(); }
 
-#if defined(USE_UPCXX)
   void put_raw_contig(int64_t* lo, int64_t* hi, void* buf) const {
     const auto elem_sz  = MemoryManagerGA::get_element_size(eltype_);
     TensorTile t        = find_tile(lo[0], lo[1], lo[2], lo[3]);

--- a/src/tamm/tensor_impl.hpp
+++ b/src/tamm/tensor_impl.hpp
@@ -41,7 +41,7 @@ public:
     offset = _offset;
   }
 
-  bool contains(int64_t i, int64_t j, int64_t k, int64_t l) {
+  bool contains(int64_t i, int64_t j, int64_t k, int64_t l) const {
     return i >= lo[0] && j >= lo[1] && i < lo[0] + dim[0] && j < lo[1] + dim[1] && k >= lo[2] &&
            l >= lo[3] && k < lo[2] + dim[2] && l < lo[3] + dim[3];
   }
@@ -465,6 +465,21 @@ public:
   }
 #endif
 
+  virtual std::vector<int64_t> local_buf_dims() const { abort(); }
+
+  virtual bool is_local_element(int64_t i, int64_t j, int64_t k, int64_t l) const { abort(); }
+
+  virtual std::vector<int64_t> local_tiles_offsets() const { abort(); }
+
+  virtual std::pair<int64_t, int64_t> local_element_offsets(int64_t i, int64_t j, int64_t k,
+                                                            int64_t l) const {
+    abort();
+  }
+
+  virtual std::vector<TensorTile>::const_iterator local_tiles_begin() const { abort(); }
+
+  virtual std::vector<TensorTile>::const_iterator local_tiles_end() const { abort(); }
+
   virtual void put_raw_contig(int64_t* lo, int64_t* hi, void* buf) const { abort(); }
 
   virtual void put_raw(int64_t* lo, int64_t* hi, void* buf) const { abort(); }
@@ -724,6 +739,11 @@ public:
   void deallocate() {
     EXPECTS(allocation_status_ == AllocationStatus::created);
 #if defined(USE_UPCXX)
+    gptrs_.clear();
+    tensor_dims_.clear();
+    local_buf_dims_.clear();
+    tiles_.clear();
+    local_tiles_.clear();
     ec_->pg().barrier();
     upcxx::delete_array(local_gptr_);
     ec_->pg().barrier();
@@ -776,7 +796,8 @@ public:
     for(int i = 0; i < ndims; i++)
       new_tiles[i] = is_irreg_tis[i] ? tis_dims[i].input_tile_sizes() : tiles_for_fixed_ts_dim[i];
 
-    int nranks = ec->pg().size().value();
+    int my_rank = ec->pg().rank().value();
+    int nranks  = ec->pg().size().value();
 
 #if defined(USE_UPCXX)
 
@@ -840,15 +861,19 @@ public:
       int64_t  owning_rank  = 0;
       int64_t* tile_offsets = new int64_t[nranks]();
 
-      memset(tile_offsets, 0x00, nranks * sizeof(*tile_offsets));
-
       for(int64_t i = 0; i < tensor_dims_[2]; i += new_tiles[2][0])
         for(int64_t j = 0; j < tensor_dims_[3]; j += new_tiles[3][0]) {
-          tiles_.push_back(TensorTile(0, 0, i, j, new_tiles[0][0], new_tiles[1][0], new_tiles[2][0],
-                                      new_tiles[3][0], owning_rank, tile_offsets[owning_rank]));
+          TensorTile new_tile(0, 0, i, j, new_tiles[0][0], new_tiles[1][0], new_tiles[2][0],
+                              new_tiles[3][0], owning_rank, tile_offsets[owning_rank]);
+          tiles_.push_back(new_tile);
+
+          if(owning_rank == my_rank) local_tiles_.push_back(new_tile);
+
           tile_offsets[owning_rank] += tile_size_in_bytes / element_size;
           owning_rank = (owning_rank + 1) % nranks;
         }
+
+      local_nelems_ = tile_offsets[my_rank];
 
       delete[] tile_offsets;
 #else
@@ -859,6 +884,7 @@ public:
     }
     else {
 #if defined(USE_UPCXX)
+
       int64_t  tile_index     = 0;
       int64_t* tile_offsets   = new int64_t[nranks]();
       int64_t  tiles_per_proc = (total_n_tiles + nranks - 1) / nranks;
@@ -867,16 +893,22 @@ public:
         for(int64_t j = 0, jj = 0; j < tensor_dims_[1]; j += new_tiles[1][jj], ++jj)
           for(int64_t k = 0, kk = 0; k < tensor_dims_[2]; k += new_tiles[2][kk], ++kk)
             for(int64_t l = 0, ll = 0; l < tensor_dims_[3]; l += new_tiles[3][ll], ++ll) {
-              const int owning_rank = tile_index / tiles_per_proc;
-              tiles_.push_back(TensorTile(i, j, k, l, new_tiles[0][ii], new_tiles[1][jj],
-                                          new_tiles[2][kk], new_tiles[3][ll], owning_rank,
-                                          tile_offsets[owning_rank]));
+              const int  owning_rank = tile_index / tiles_per_proc;
+              TensorTile new_tile(i, j, k, l, new_tiles[0][ii], new_tiles[1][jj], new_tiles[2][kk],
+                                  new_tiles[3][ll], owning_rank, tile_offsets[owning_rank]);
+              tiles_.push_back(new_tile);
+
+              if(owning_rank == my_rank) local_tiles_.push_back(new_tile);
+
               tile_offsets[owning_rank] +=
                 new_tiles[0][ii] * new_tiles[1][jj] * new_tiles[2][kk] * new_tiles[3][ll];
               tile_index++;
             }
 
-      local_nelems_ = tile_offsets[upcxx::rank_me()];
+      if(local_nelems_ = tile_offsets[my_rank])
+        for(int i = 4 - ndims; i < 4; ++i)
+          local_buf_dims_.push_back(local_tiles_.back().lo[i] + local_tiles_.back().dim[i] -
+                                    local_tiles_.front().lo[i]);
 
       local_gptr_ = upcxx::new_array<uint8_t>(local_nelems_ * element_size);
       memset(local_gptr_.local(), 0x00, local_nelems_ * element_size);
@@ -989,13 +1021,23 @@ public:
     update_status(AllocationStatus::created);
   }
 
-#if defined(USE_UPCXX)
-  TensorTile find_tile(int64_t i, int64_t j, int64_t k, int64_t l) const {
-    for(auto tile = tiles_.begin(), e = tiles_.end(); tile != e; tile++) {
-      TensorTile t = *tile;
-      if(t.contains(i, j, k, l)) { return t; }
-    }
-    abort();
+#ifdef USE_UPCXX
+  const TensorTile& find_tile(int64_t i, int64_t j, int64_t k, int64_t l) const {
+    auto t = std::find_if(tiles_.cbegin(), tiles_.cend(), [i, j, k, l](const TensorTile& tile) {
+      return tile.contains(i, j, k, l);
+    });
+
+    if(t != tiles_.cend()) return *t;
+    else abort();
+  }
+
+  std::optional<TensorTile> find_local_tile(int64_t i, int64_t j, int64_t k, int64_t l) const {
+    auto t =
+      std::find_if(local_tiles_.cbegin(), local_tiles_.cend(),
+                   [i, j, k, l](const TensorTile& tile) { return tile.contains(i, j, k, l); });
+
+    if(t != local_tiles_.cend()) return *t;
+    else return std::nullopt;
   }
 #endif
 
@@ -1114,6 +1156,75 @@ public:
                                reinterpret_cast<void*>(&ptr), &len);
 #endif
     return ptr;
+  }
+
+  std::vector<int64_t> local_buf_dims() const {
+#ifdef USE_UPCXX
+    assert(!is_block_cyclic_);
+    return local_buf_dims_.size() > 0 ? local_buf_dims_ : std::vector<int64_t>(num_modes());
+#else
+    throw std::runtime_error("Function local_buf_dims not defined for GA backend.");
+#endif
+  }
+
+  bool is_local_element(int64_t i, int64_t j, int64_t k, int64_t l) const {
+#ifdef USE_UPCXX
+    auto t = find_local_tile(i, j, k, l);
+    if(t.has_value()) return true;
+    return false;
+#else
+    throw std::runtime_error("Function is_local_element not defined for GA backend.");
+#endif
+  }
+
+  std::vector<int64_t> local_tiles_offsets() const {
+#ifdef USE_UPCXX
+    std::vector<int64_t> offsets(local_tiles_.size());
+    std::transform(local_tiles_.cbegin(), local_tiles_.cend(), offsets.begin(),
+                   [](const auto& tile) { return tile.offset; });
+    return offsets;
+#else
+    throw std::runtime_error("Function local_tiles_offsets not defined for GA backend.");
+#endif
+  }
+
+  std::pair<int64_t, int64_t> local_element_offsets(int64_t i, int64_t j, int64_t k,
+                                                    int64_t l) const {
+#ifdef USE_UPCXX
+    auto t = find_local_tile(i, j, k, l);
+
+    if(t.has_value()) {
+      int64_t i_offset = i - t->lo[0];
+      int64_t j_offset = j - t->lo[1];
+      int64_t k_offset = k - t->lo[2];
+      int64_t l_offset = l - t->lo[3];
+      int64_t tile_offset =
+        l_offset + t->dim[3] * (k_offset + t->dim[2] * (j_offset + t->dim[1] * i_offset));
+
+      //        outer       inner
+      return {t->offset, tile_offset};
+    }
+
+    return {-1, -1};
+#else
+    throw std::runtime_error("Function local_element_offsets not defined for GA backend.");
+#endif
+  }
+
+  std::vector<TensorTile>::const_iterator local_tiles_begin() const {
+#ifdef USE_UPCXX
+    return local_tiles_.cbegin();
+#else
+    throw std::runtime_error("Function local_tiles_begin not defined for GA backend.");
+#endif
+  }
+
+  std::vector<TensorTile>::const_iterator local_tiles_end() const {
+#ifdef USE_UPCXX
+    return local_tiles_.cend();
+#else
+    throw std::runtime_error("Function local_tiles_end not defined for GA backend.");
+#endif
   }
 
 #if defined(USE_UPCXX)
@@ -1280,13 +1391,15 @@ protected:
   }
 
 #if defined(USE_UPCXX)
+  ElementType                             eltype_;
+  int64_t                                 local_nelems_;
+  ProcGrid                                proc_grid_;
   upcxx::global_ptr<uint8_t>              local_gptr_;
   std::vector<upcxx::global_ptr<uint8_t>> gptrs_;
-  ProcGrid                                proc_grid_;
   std::vector<int64_t>                    tensor_dims_;
-  ElementType                             eltype_;
+  std::vector<int64_t>                    local_buf_dims_;
   std::vector<TensorTile>                 tiles_;
-  int64_t                                 local_nelems_;
+  std::vector<TensorTile>                 local_tiles_;
 #else
   int ga_;
   ProcGrid proc_grid_;

--- a/src/tamm/tensor_impl.hpp
+++ b/src/tamm/tensor_impl.hpp
@@ -1030,7 +1030,7 @@ public:
     });
 
     if(t != tiles_.cend()) return *t;
-    else abort();
+    abort();
   }
 
   std::optional<TensorTile> find_local_tile(int64_t i, int64_t j, int64_t k, int64_t l) const {
@@ -1039,7 +1039,7 @@ public:
                    [i, j, k, l](const TensorTile& tile) { return tile.contains(i, j, k, l); });
 
     if(t != local_tiles_.cend()) return *t;
-    else return std::nullopt;
+    return std::nullopt;
   }
 #endif
 


### PR DESCRIPTION
This PR adds some handy functions to the `DenseTensorImpl` class, so codes like `CholeskyDecomp` can be easily adapted to directly use `TAMM` instead of `ga_over_upcxx`.

**None of these modifications is upcxx-related.**